### PR TITLE
Keeping Settings Reference & Only Normalize Changed Element

### DIFF
--- a/core/Category.js
+++ b/core/Category.js
@@ -99,7 +99,7 @@ export default class Category {
      * @returns this for method chaining
      */
     _reBuildConfig() {
-        this.parentClass.settings = this.parentClass.configsClass._normalizeSettings()
+        this.parentClass.configsClass._normalizeSettings(this.parentClass.settings)
         this.createElementClass._hideElement(this.parentClass.settings)
 
         return this

--- a/core/Category.js
+++ b/core/Category.js
@@ -95,11 +95,12 @@ export default class Category {
     }
 
     /**
-     * - Re-builds the normalize settings
+     * - Updates the parent class' element
+     * @param {any} element
      * @returns this for method chaining
      */
-    _reBuildConfig() {
-        this.parentClass.configsClass._normalizeSettings(this.parentClass.settings)
+    _updateElement(element) {
+        this.parentClass.settings[element.name] = element.value
         this.createElementClass._hideElement(this.parentClass.settings)
 
         return this

--- a/core/CreateElement.js
+++ b/core/CreateElement.js
@@ -259,7 +259,7 @@ export default class CreateElement {
 
         this.triggerListeners(obj, newValue)
         obj.value = newValue
-        this.categoryClass._reBuildConfig()
+        this.categoryClass._updateElement(obj)
     }
 
     // The following methods do not have jsdocs due to the fact that
@@ -489,8 +489,7 @@ export default class CreateElement {
             const isEnabled = obj.configObj.shouldShow(data)
             const component = obj.component
 
-            // Possibly get rid of this error
-            if (typeof(isEnabled) !== "boolean") throw new Error(`Error while attempting to check for shouldShow. ${obj.configObj.shouldShow} does not return a valid Boolean`)
+            if (typeof(isEnabled) === "object") throw new Error(`Error while attempting to check for shouldShow. ${obj.configObj.shouldShow} does not return a valid Boolean`)
 
             if (!isEnabled) {
                 this._hide(component)

--- a/core/DefaultConfig.js
+++ b/core/DefaultConfig.js
@@ -206,15 +206,39 @@ export default class DefaultConfig {
     /**
      * @private
      * - Internal use.
-     * - Makes the current config into an actual dev friendly format
+     * - Forms and updates the current config into an actual dev friendly format
+     * - e.g instead of `[Settings: { name: "configName", text: "config stuff" ...etc }]`
+     * converts it into `{ configName: false }`
+     * @param {Object?}  
+     * @returns {P & { getConfig() => import("./Settings").default<this> }}
+     */
+    _normalizeSettings(settings) {
+        // TODO: change this to only be ran once per feature change
+        // rather than everytime one changes re-scan the entire thing and re-build it
+        this.config.forEach(obj => {
+            obj.settings.forEach(settingsObj => {
+                if (settingsObj.type === ConfigTypes.MULTICHECKBOX) {
+                    settingsObj.options.forEach(opts => {
+                        settings[opts.configName] = opts.value
+                    })
+                    return
+                }
+
+                settings[settingsObj.name] = settingsObj.value
+            })
+        })
+    }
+
+    /**
+     * @private
+     * - Internal use.
+     * - Builds the config into an actual dev friendly format
      * - e.g instead of `[Settings: { name: "configName", text: "config stuff" ...etc }]`
      * converts it into `{ configName: false }`
      * @returns {P & { getConfig() => import("./Settings").default<this> }}
      */
-    _normalizeSettings() {
-        // TODO: change this to only be ran once per feature change
-        // rather than everytime one changes re-scan the entire thing and re-build it
-        let settings = {}
+    _initSettings() {
+        const settings = {}
 
         this.config.forEach(obj => {
             obj.settings.forEach(settingsObj => {

--- a/core/Search.js
+++ b/core/Search.js
@@ -123,17 +123,6 @@ export default class SearchElement {
     }
 
     /**
-     * - Re-builds the normalize settings
-     * @returns this for method chaining
-     */
-    _reBuildConfig() {
-        this.parentClass.configsClass._normalizeSettings(this.parentClass.settings)
-        this.createElementClass._hideElement(this.parentClass.settings)
-
-        return this
-    }
-
-    /**
      * - Hides the [rightBlock] component from the [mainRightBlock]
      * and sets this category unselected
      */

--- a/core/Search.js
+++ b/core/Search.js
@@ -23,7 +23,7 @@ export default class SearchElement {
         this.matches = null
         this.hasSearched = false
 
-        this.rightBlock = new ScrollComponent("no elements found", 5.0)
+        this.rightBlock = new ScrollComponent("No elements found...", 5.0)
             .setX((1).pixel())
             .setY((1).pixel())
             .setWidth((98).percent())

--- a/core/Search.js
+++ b/core/Search.js
@@ -127,7 +127,7 @@ export default class SearchElement {
      * @returns this for method chaining
      */
     _reBuildConfig() {
-        this.parentClass.settings = this.parentClass.configsClass._normalizeSettings()
+        this.parentClass.configsClass._normalizeSettings(this.parentClass.settings)
         this.createElementClass._hideElement(this.parentClass.settings)
 
         return this

--- a/core/Settings.js
+++ b/core/Settings.js
@@ -113,9 +113,9 @@ export default class Settings {
         this.configsClass = this.defaultConfig._init() // keeping the same name because too lazy to find where else i use it
         this.config = this.configsClass.config
         /**
-         * @type {ReturnType<DefaultConfig["_normalizeSettings"]>}
+         * @type {ReturnType<DefaultConfig["_initSettings"]>}
          */
-        this.settings = this.configsClass._normalizeSettings()
+        this.settings = this.configsClass._initSettings()
 
         // Categories variables
         this.categories = new Map()
@@ -361,7 +361,7 @@ export default class Settings {
 
         let oldv = configObj.value
         configObj.value = value
-        this.settings = this.configsClass._normalizeSettings()
+        this.configsClass._normalizeSettings(this.settings)
         this.apply()
 
         // Trigger listener

--- a/example/config.js
+++ b/example/config.js
@@ -260,5 +260,5 @@ config
     .setScheme(currentScheme)
     .apply()
 
-// Now we export the [config.settings] as a default function
-export default () => config.settings
+// Now we export the [config.settings]
+export default config.settings

--- a/example/index.js
+++ b/example/index.js
@@ -6,7 +6,7 @@ import settings from "./config"
 // For example only running a feature whenever "testingSwitch" is enabled
 register("step", () => {
     // If it's disabled we return (won't keep going further down)
-    if (!settings().testingSwitch) return
+    if (!settings.testingSwitch) return
 
     // Otherwise (if it's enabled) we say something in chat
     ChatLib.chat("testingSwitch is enabled!")
@@ -20,7 +20,7 @@ register("command", (...args) => {
     // If no arguments were passed to the command
     // (meaning only "/mytest" was ran and not "/mytest something here")
     // we open our Amaterasu gui
-    if (!args.length) return settings().getConfig().openGui()
+    if (!args.length) return settings.getConfig().openGui()
 
     // If args[0] is defined we do something else
     if (args[0]) {
@@ -33,6 +33,6 @@ register("command", (...args) => {
 
 // We can also use registerListener from here
 // as well as all the other options that [Settings] class gives
-settings().getConfig().registerListener("testingSwitch", (previousValue, newValue) => {
+settings.getConfig().registerListener("testingSwitch", (previousValue, newValue) => {
     ChatLib.chat(`looks like testingSwitch changed | ${previousValue} -> ${newValue} |`)
 })


### PR DESCRIPTION
- Change rebuilding entire config to only change the passed element
- Generalized function for handling element updates
- Allow devs to export settings as a constant object
- Improve text shown when the Search concludes no results
- Remove unused function from Search